### PR TITLE
Fix Nextcloud webdav incompatibility

### DIFF
--- a/app/src/main/java/fr/hellpc/mirror/workers/backup/Backup_WebDav.kt
+++ b/app/src/main/java/fr/hellpc/mirror/workers/backup/Backup_WebDav.kt
@@ -179,8 +179,20 @@ class Backup_WebDav(
                 .build()
 
             // Some servers seem to not allow root url listing
-            val checkUrl = if(target.path.isNotBlank())
-                target.path.toURL(false)
+            val checkUrl = if(target.path.isNotBlank()) {
+                val cleanPath = target.path.trim('/')
+                val rootSegment = if(cleanPath.contains(".php/", ignoreCase = true)) {
+                    val phpIndex = cleanPath.indexOf(".php/", ignoreCase = true) + 5
+                    val beforePhp = cleanPath.substring(0, phpIndex)
+                    val firstDir = cleanPath.substring(phpIndex).substringBefore('/')
+
+                    beforePhp + firstDir
+                }
+                else
+                    cleanPath.substringBefore('/')
+
+                rootSegment.toURL(false)
+            }
             else
                 "".toURL(false)
 

--- a/app/src/main/java/fr/hellpc/mirror/workers/backup/Backup_WebDav.kt
+++ b/app/src/main/java/fr/hellpc/mirror/workers/backup/Backup_WebDav.kt
@@ -180,7 +180,7 @@ class Backup_WebDav(
 
             // Some servers seem to not allow root url listing
             val checkUrl = if(target.path.isNotBlank())
-                target.path.substringBefore('/').toURL(false)
+                target.path.toURL(false)
             else
                 "".toURL(false)
 


### PR DESCRIPTION
This PR solves https://github.com/He11PC/android-mirror/issues/3 by running the connection check against the fully assembled URL instead of the base URL (which is not a valid webdav URL in Nextcloud).

It's a quick fix and I haven't checked for any side effects but it seems to make the actual job execution behave more consistently with the configuration dialog.
I have a build of this branch running on my device and Nextcloud webdav now works flawlessly.